### PR TITLE
Remove L.Mixin.Events warnings

### DIFF
--- a/leaflet.latlng-graticule.js
+++ b/leaflet.latlng-graticule.js
@@ -8,7 +8,7 @@
 (function (window, document, undefined) {
 
     L.LatLngGraticule = L.Layer.extend({
-        includes: L.Mixin.Events,
+        includes: L.Evented.prototype || L.Mixin.Events,
 
         options: {
             showLabel: true,


### PR DESCRIPTION
L.Mixin.Events is deprecated and will be removed in future Leaflet builds.